### PR TITLE
enforce minimum ocaml version of 4.03 due to use of `result`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.t
 script: bash -ex .travis-opam.sh
 env:
   global:
-  - EXTRA_REMOTES="https://github.com/yomimono/mirage-dev.git#split-tcpip-module-types"
+  - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
   - PINS="mirage-protocols.1.0.0:. mirage-protocols-lwt.1.0.0:."
   matrix:
-  - OCAML_VERSION=4.02 PACKAGE="mirage-protocols-lwt"
   - OCAML_VERSION=4.03 PACKAGE="mirage-protocols-lwt"
   - OCAML_VERSION=4.04 PACKAGE="mirage-protocols-lwt"

--- a/opam
+++ b/opam
@@ -19,4 +19,4 @@ depends: [
   "fmt"
 ]
 
-available: [ ocaml-version >= "4.01.0"]
+available: [ ocaml-version >= "4.03.0"]


### PR DESCRIPTION
or else

```
# File "src/mirage_protocols.ml", line 8, characters 26-73:
# Warning 50: unattached documentation comment (ignored)
# File "src/mirage_protocols.ml", line 16, characters 15-90:
# Warning 50: unattached documentation comment (ignored)
# File "src/mirage_protocols.ml", line 42, characters 28-48:
# Error: Unbound type constructor result
# Command exited with code 2.
```