### PR TITLE
ethif: ip: allow the MTU to be queried

### DIFF
--- a/src/mirage_protocols.ml
+++ b/src/mirage_protocols.ml
@@ -42,6 +42,7 @@ module type ETHIF = sig
   val write: t -> buffer -> (unit, error) result io
   val writev: t -> buffer list -> (unit, error) result io
   val mac: t -> macaddr
+  val mtu: t -> int
   val input:
     arpv4:(buffer -> unit io) ->
     ipv4:(buffer -> unit io) ->
@@ -72,6 +73,7 @@ module type IP = sig
   type uipaddr
   val to_uipaddr: ipaddr -> uipaddr
   val of_uipaddr: uipaddr -> ipaddr option
+  val mtu: t -> int
 end
 
 module type ARP = sig

--- a/src/mirage_protocols.mli
+++ b/src/mirage_protocols.mli
@@ -41,6 +41,10 @@ module type ETHIF = sig
   val mac: t -> macaddr
   (** [mac nf] is the MAC address of [nf]. *)
 
+  val mtu: t -> int
+  (** [mtu nf] is the Maximum Transmission Unit of the [nf] i.e. the maximum
+      size of the payload, not including the ethernet frame header. *)
+
   val input:
     arpv4:(buffer -> unit io) ->
     ipv4:(buffer -> unit io) ->
@@ -155,6 +159,10 @@ module type IP = sig
   (** Project a universal IP address into the version supported by the
       current implementation. Return [None] if there is a version
       mismatch. *)
+
+  val mtu: t -> int
+  (** [mtu ip] is the Maximum Transmission Unit of the [ip] i.e. the maximum
+      size of the payload, not including the IP header. *)
 
 end
 


### PR DESCRIPTION
Previously we had no way to discover the MTU of an ethernet or an IP interface. This patch adds a function `mtu: t -> int` to both.

Signed-off-by: David Scott <dave@recoil.org>