### PR TITLE
add lower bounds of mirage-flow and mirage-device, as done in earlier releases

### DIFF
--- a/mirage-protocols.opam
+++ b/mirage-protocols.opam
@@ -15,8 +15,8 @@ build: [
 
 depends: [
   "jbuilder" {build & >="1.0+beta9"}
-  "mirage-device"
-  "mirage-flow"
+  "mirage-device" {>= "1.0.0"}
+  "mirage-flow" {>= "1.2.0"}
   "fmt"
   "duration"
 ]


### PR DESCRIPTION
also PR in opam-repository https://github.com/ocaml/opam-repository/pull/11585