### PR TITLE
remove unneeded types (ethif, prefix) from module type IP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script: bash -ex .travis-opam.sh
 env:
   global:
   - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
-  - PINS="mirage-protocols:. mirage-protocols-lwt:."
+  - PINS="mirage-protocols:. mirage-protocols-lwt:. tcpip:https://github.com/hannesm/mirage-tcpip.git#less-types"
   - DEPOPTS="mirage-protocols-lwt"
   - REVDEPS=true
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script: bash -ex .travis-opam.sh
 env:
   global:
   - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
-  - PINS="mirage-protocols:. mirage-protocols-lwt:. tcpip:https://github.com/hannesm/mirage-tcpip.git#less-types mirage-stack:https://github.com/hannesm/mirage-stack.git#less-types mirage-stack-lwt:https://github.com/hannesm/mirage-stack.git#less-types"
+  - PINS="mirage-protocols:. mirage-protocols-lwt:."
   - DEPOPTS="mirage-protocols-lwt"
   - REVDEPS=true
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script: bash -ex .travis-opam.sh
 env:
   global:
   - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
-  - PINS="mirage-protocols:. mirage-protocols-lwt:. tcpip:https://github.com/hannesm/mirage-tcpip.git#less-types"
+  - PINS="mirage-protocols:. mirage-protocols-lwt:. tcpip:https://github.com/hannesm/mirage-tcpip.git#less-types mirage-stack:https://github.com/hannesm/mirage-stack.git#less-types mirage-stack-lwt:https://github.com/hannesm/mirage-stack.git#less-types"
   - DEPOPTS="mirage-protocols-lwt"
   - REVDEPS=true
   matrix:

--- a/lwt/mirage_protocols_lwt.ml
+++ b/lwt/mirage_protocols_lwt.ml
@@ -16,12 +16,10 @@ module type IP = Mirage_protocols.IP
 
 module type IPV4 = IP
   with type ipaddr = Ipaddr.V4.t
-   and type prefix = Ipaddr.V4.Prefix.t
 
 (** IPv6 stack *)
 module type IPV6 = IP
   with type ipaddr = Ipaddr.V6.t
-   and type prefix = Ipaddr.V6.Prefix.t
 
 (** ICMP module *)
 module type ICMP = Mirage_protocols.ICMP

--- a/src/mirage_protocols.ml
+++ b/src/mirage_protocols.ml
@@ -36,7 +36,6 @@ module type ETHIF = sig
   type error = private [> Ethif.error]
   val pp_error: error Fmt.t
   type buffer
-  type netif
   type macaddr
   include Mirage_device.S
   val write: t -> buffer -> (unit, error) result io
@@ -111,7 +110,6 @@ module type UDP = sig
   type error
   val pp_error: error Fmt.t
   type buffer
-  type ip
   type ipaddr
   type ipinput
   include Mirage_device.S
@@ -133,7 +131,6 @@ module type TCP = sig
   type error = private [> Tcp.error]
   type write_error = private [> Tcp.write_error]
   type buffer
-  type ip
   type ipaddr
   type ipinput
   type flow

--- a/src/mirage_protocols.ml
+++ b/src/mirage_protocols.ml
@@ -53,9 +53,7 @@ module type IP = sig
   type error = private [> Ip.error]
   val pp_error: error Fmt.t
   type buffer
-  type ethif
   type ipaddr
-  type prefix
   include Mirage_device.S
   type callback = src:ipaddr -> dst:ipaddr -> buffer -> unit io
   val input:

--- a/src/mirage_protocols.mli
+++ b/src/mirage_protocols.mli
@@ -80,14 +80,8 @@ module type IP = sig
   type buffer
     (** The type for memory buffers. *)
 
-  type ethif
-  (** The type for ethernet devices. *)
-
   type ipaddr
   (** The type for IP addresses. *)
-
-  type prefix
-  (** The type for IP prefixes. *)
 
   include Mirage_device.S
 

--- a/src/mirage_protocols.mli
+++ b/src/mirage_protocols.mli
@@ -23,9 +23,6 @@ module type ETHIF = sig
   type buffer
   (** The type for memory buffers. *)
 
-  type netif
-  (** The type for ethernet network interfaces. *)
-
   type macaddr
   (** The type for unique MAC identifiers. *)
 
@@ -271,9 +268,6 @@ module type UDP = sig
   type buffer
   (** The type for memory buffers. *)
 
-  type ip
-  (** The type for IPv4/6 stacks for this stack to connect to. *)
-
   type ipaddr
   (** The type for an IP address representations. *)
 
@@ -343,9 +337,6 @@ module type TCP = sig
 
   type buffer
   (** The type for memory buffers. *)
-
-  type ip
-  (** The type for IPv4 stacks for this stack to connect to. *)
 
   type ipaddr
   (** The type for IP address representations. *)


### PR DESCRIPTION
I never understood why they need to be here.  careful, this needs to be merged/released after the PRs to mirage-tcpip and charrua (anyone else has an IP implementation? sorry this may break your API)

- charrua PR https://github.com/mirage/charrua-core/pull/83
- tcpip PR https://github.com/mirage/mirage-tcpip/pull/371
- mirage-qubes PR https://github.com/mirage/mirage-qubes/pull/24
- mirage-stack https://github.com/mirage/mirage-stack/pull/11
- mirage https://github.com/mirage/mirage/pull/920