### PR TITLE
Rename ethif to ethernet

### DIFF
--- a/lwt/mirage_protocols_lwt.ml
+++ b/lwt/mirage_protocols_lwt.ml
@@ -1,4 +1,4 @@
-module type ETHIF = Mirage_protocols.ETHIF
+module type ETHERNET = Mirage_protocols.ETHERNET
   with type 'a io = 'a Lwt.t
    and type buffer = Cstruct.t
    and type macaddr = Macaddr.t

--- a/src/mirage_protocols.ml
+++ b/src/mirage_protocols.ml
@@ -1,4 +1,4 @@
-module Ethif = struct
+module Ethernet = struct
   type error = [ `Exceeds_mtu ]
   let pp_error ppf = function
     | `Exceeds_mtu -> Fmt.string ppf "exceeds MTU"
@@ -45,13 +45,13 @@ module Tcp = struct
   | #error as e                   -> pp_error ppf e
 end
 
-module type ETHIF = sig
-  type error = private [> Ethif.error]
+module type ETHERNET = sig
+  type error = private [> Ethernet.error]
   val pp_error: error Fmt.t
   type buffer
   type macaddr
   include Mirage_device.S
-  val write: t -> ?src:macaddr -> macaddr -> Ethif.proto -> ?size:int ->
+  val write: t -> ?src:macaddr -> macaddr -> Ethernet.proto -> ?size:int ->
     (buffer -> int) -> (unit, error) result io
   val mac: t -> macaddr
   val mtu: t -> int

--- a/src/mirage_protocols.mli
+++ b/src/mirage_protocols.mli
@@ -2,12 +2,9 @@
 
         {e %%VERSION%% } *)
 
-(** {1 Ethernet stack}
+(** {2 Ethernet layer} *)
 
-    An Ethernet stack that parses frames from a network device and
-    can associate them with IP address via ARP. *)
-
-module Ethif : sig
+module Ethernet : sig
   type error = [ `Exceeds_mtu ]
   val pp_error: error Fmt.t
 
@@ -15,9 +12,15 @@ module Ethif : sig
   val pp_proto: proto Fmt.t
 end
 
-module type ETHIF = sig
+(** Ethernet (IEEE 802.3) is a widely used data link layer. The hardware is
+   usually a twisted pair or fibre connection, on the software side it consists
+   of an Ethernet header where source and destination mac addresses, and a type
+   field, indicating the type of the next layer, are present. The Ethernet layer
+   consists of network card mac address and MTU information, and provides
+   decapsulation and encapsulation. *)
+module type ETHERNET = sig
 
-  type error = private [> Ethif.error]
+  type error = private [> Ethernet.error]
   (** The type for ethernet interface errors. *)
 
   val pp_error: error Fmt.t
@@ -31,7 +34,7 @@ module type ETHIF = sig
 
   include Mirage_device.S
 
-  val write: t -> ?src:macaddr -> macaddr -> Ethif.proto -> ?size:int ->
+  val write: t -> ?src:macaddr -> macaddr -> Ethernet.proto -> ?size:int ->
     (buffer -> int) -> (unit, error) result io
   (** [write eth ~src dst proto ~size payload] outputs an ethernet frame which
      header is filled by [eth], and its payload is the buffer from the call to
@@ -54,7 +57,7 @@ module type ETHIF = sig
       it depending on the protocol to the callback. *)
 end
 
-(** {1 IP stack} *)
+(** {2 IP stack} *)
 
 (** IP errors. *)
 module Ip : sig
@@ -69,7 +72,9 @@ module Ip : sig
   val pp_proto: proto Fmt.t
 end
 
-(** An IP stack that parses Ethernet frames into IP packets *)
+(** An Internet Protocol (IP) stack reassembles IP fragments into packets,
+   removes the IP header, and on the sending side fragments overlong payload
+   and inserts IP headers. *)
 module type IP = sig
 
   type error = private [> Ip.error]
@@ -155,7 +160,7 @@ module type IP = sig
 
 end
 
-(** {1 ARP} *)
+(** {2 ARP} *)
 
 (** Arp error. *)
 module Arp : sig
@@ -209,19 +214,19 @@ module type ARP = sig
   val input : t -> buffer -> unit io
 end
 
-(** {1 IPv4 stack} *)
+(** {2 IPv4 stack} *)
 module type IPV4 = sig
   include IP
 end
 
-(** {1 IPv6 stack} *)
+(** {2 IPv6 stack} *)
 module type IPV6 = sig
   include IP
 end
 
 (** No Icmp module, as there are no exposed error polymorphic variants *)
 
-(** {1 ICMP module} *)
+(** {2 ICMP module} *)
 module type ICMP = sig
   include Mirage_device.S
 
@@ -250,7 +255,7 @@ module type ICMPV4 = sig
   include ICMP
 end
 
-(** {1 UDP stack} *)
+(** {2 UDP stack} *)
 
 (** No Udp module, as there are no exposed error polymorphic variants *)
 
@@ -296,7 +301,7 @@ module type UDP = sig
 
 end
 
-(** {1 TCP stack} *)
+(** {2 TCP stack} *)
 
 (** TCP errors. *)
 module Tcp : sig


### PR DESCRIPTION
The `netif` (mirage-net) is our network device. ethernet is the ethernet layer.
this PR is on top of #15 and should be merged thereafter (but before a 2.0 release :)). required reverse dependency updates:
- [ ] mirage (mainly types) https://github.com/mirage/mirage/pull/972
- [ ] ethernet https://github.com/mirage/ethernet/pull/4
- [ ] arp https://github.com/mirage/arp/pull/14
- [ ] tcpip https://github.com/mirage/mirage-tcpip/pull/395
- [ ] charrua https://github.com/mirage/charrua-core/pull/95
- [ ] mirage-skeleton https://github.com/mirage/mirage-skeleton/pull/265