### PR TITLE
remove uipaddr type from IP module type; replace with pp_ipaddr

### DIFF
--- a/lwt/mirage_protocols_lwt.ml
+++ b/lwt/mirage_protocols_lwt.ml
@@ -15,7 +15,6 @@ module type ARP = Mirage_protocols.ARP
 module type IP = Mirage_protocols.IP
   with type 'a io = 'a Lwt.t
    and type buffer = Cstruct.t
-   and type uipaddr = Ipaddr.t
 
 (** IPv4 stack *)
 module type IPV4 = IP

--- a/src/mirage_protocols.ml
+++ b/src/mirage_protocols.ml
@@ -66,6 +66,7 @@ module type IP = sig
   val pp_error: error Fmt.t
   type buffer
   type ipaddr
+  val pp_ipaddr : ipaddr Fmt.t
   include Mirage_device.S
   type callback = src:ipaddr -> dst:ipaddr -> buffer -> unit io
   val input:
@@ -79,9 +80,6 @@ module type IP = sig
   val src: t -> dst:ipaddr -> ipaddr
   val set_ip: t -> ipaddr -> unit io
   val get_ip: t -> ipaddr list
-  type uipaddr
-  val to_uipaddr: ipaddr -> uipaddr
-  val of_uipaddr: uipaddr -> ipaddr option
   val mtu: t -> int
 end
 

--- a/src/mirage_protocols.mli
+++ b/src/mirage_protocols.mli
@@ -84,10 +84,13 @@ module type IP = sig
   (** [pp_error] is the pretty-printer for errors. *)
 
   type buffer
-    (** The type for memory buffers. *)
+  (** The type for memory buffers. *)
 
   type ipaddr
   (** The type for IP addresses. *)
+
+  val pp_ipaddr : ipaddr Fmt.t
+  (** [pp_ipaddr] is the pretty-printer for IP addresses. *)
 
   include Mirage_device.S
 
@@ -140,19 +143,6 @@ module type IP = sig
   (** Get the IP addresses associated with this interface. For IPv4, only
    *  one IP address can be set at a time, so the list will always be of
    *  length 1 (and may be the default value, 0.0.0.0). *)
-
-  type uipaddr
-  (** The type for universal IP addresses. It supports all the
-      possible versions. *)
-
-  val to_uipaddr: ipaddr -> uipaddr
-  (** Convert an IP address with a specific version (eg. V4) into a
-      universal IP address. *)
-
-  val of_uipaddr: uipaddr -> ipaddr option
-  (** Project a universal IP address into the version supported by the
-      current implementation. Return [None] if there is a version
-      mismatch. *)
 
   val mtu: t -> int
   (** [mtu ip] is the Maximum Transmission Unit of the [ip] i.e. the maximum


### PR DESCRIPTION
`uipaddr` seems only to be used to print the IP addresses for human
consumption.  Replace it with a requirement for `pp_ipaddr`, for direct
use in printing invocations.