### PR TITLE
Add ttl parameter to UDP and ICMP write

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script: bash -ex .travis-opam.sh
 env:
   global:
   - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
-  - PINS="mirage-protocols:. mirage-protocols-lwt:. mirage-tcpip:https://github.com/phaer/mirage-tcpip.git#master"
+  - PINS="mirage-protocols:. mirage-protocols-lwt:. tcpip:https://github.com/phaer/mirage-tcpip.git#master"
   - DEPOPTS="mirage-protocols-lwt"
   - REVDEPS=true
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ script: bash -ex .travis-opam.sh
 env:
   global:
   - EXTRA_REMOTES="https://github.com/mirage/mirage-dev.git"
-  - PINS="mirage-protocols:. mirage-protocols-lwt:."
+  - PINS="mirage-protocols:. mirage-protocols-lwt:. mirage-tcpip:https://github.com/phaer/mirage-tcpip.git#master"
   - DEPOPTS="mirage-protocols-lwt"
   - REVDEPS=true
   matrix:

--- a/src/mirage_protocols.ml
+++ b/src/mirage_protocols.ml
@@ -125,7 +125,7 @@ module type UDP = sig
   include Mirage_device.S
   type callback = src:ipaddr -> dst:ipaddr -> src_port:int -> buffer -> unit io
   val input: listeners:(dst_port:int -> callback option) -> t -> ipinput
-  val write: ?src_port:int -> dst:ipaddr -> dst_port:int -> t -> buffer ->
+  val write: ?src_port:int -> ?ttl:int -> dst:ipaddr -> dst_port:int -> t -> buffer ->
     (unit, error) result io
 end
 

--- a/src/mirage_protocols.ml
+++ b/src/mirage_protocols.ml
@@ -111,7 +111,7 @@ module type ICMP = sig
   type error
   val pp_error: error Fmt.t
   val input : t -> src:ipaddr -> dst:ipaddr -> buffer -> unit io
-  val write : t -> dst:ipaddr -> buffer -> (unit, error) result io
+  val write : t -> dst:ipaddr -> ?ttl:int -> buffer -> (unit, error) result io
 end
 
 module type ICMPV4 = ICMP

--- a/src/mirage_protocols.mli
+++ b/src/mirage_protocols.mli
@@ -283,7 +283,7 @@ module type UDP = sig
       return a concrete handler or a [None], which results in the
       datagram being dropped. *)
 
-  val write: ?src_port:int -> dst:ipaddr -> dst_port:int -> t -> buffer ->
+  val write: ?src_port:int -> ?ttl:int -> dst:ipaddr -> dst_port:int -> t -> buffer ->
     (unit, error) result io
   (** [write ~src_port ~dst ~dst_port udp data] is a thread
       that writes [data] from an optional [src_port] to a [dst]

--- a/src/mirage_protocols.mli
+++ b/src/mirage_protocols.mli
@@ -236,7 +236,7 @@ module type ICMP = sig
   (** [input t src dst buffer] reacts to the ICMP message in
       [buffer]. *)
 
-  val write : t -> dst:ipaddr -> buffer -> (unit, error) result io
+  val write : t -> dst:ipaddr -> ?ttl:int -> buffer -> (unit, error) result io
   (** [write t dst buffer] sends the ICMP message in [buffer] to [dst]
       over IP. *)
 end

--- a/src/mirage_protocols.mli
+++ b/src/mirage_protocols.mli
@@ -238,7 +238,7 @@ module type ICMP = sig
 
   val write : t -> dst:ipaddr -> ?ttl:int -> buffer -> (unit, error) result io
   (** [write t dst ~ttl buffer] sends the ICMP message in [buffer] to [dst]
-      over IP. Passes [ttl] to the IP stack if given. *)
+      over IP. Passes the time-to-live ([ttl]) to the IP stack if given. *)
 end
 
 module type ICMPV4 = sig
@@ -285,9 +285,9 @@ module type UDP = sig
 
   val write: ?src_port:int -> ?ttl:int -> dst:ipaddr -> dst_port:int -> t -> buffer ->
     (unit, error) result io
-  (** [write ~src_port ?ttl ~dst ~dst_port udp data] is a thread
+  (** [write ~src_port ~ttl ~dst ~dst_port udp data] is a thread
       that writes [data] from an optional [src_port] to a [dst]
-      and [dst_port] IPv4 address pair. An optional [ttl] is passed
+      and [dst_port] IPv4 address pair. An optional time-to-live ([ttl]) is passed
       through to the IP stack. *)
 
 end

--- a/src/mirage_protocols.mli
+++ b/src/mirage_protocols.mli
@@ -237,8 +237,8 @@ module type ICMP = sig
       [buffer]. *)
 
   val write : t -> dst:ipaddr -> ?ttl:int -> buffer -> (unit, error) result io
-  (** [write t dst buffer] sends the ICMP message in [buffer] to [dst]
-      over IP. *)
+  (** [write t dst ?ttl buffer] sends the ICMP message in [buffer] to [dst]
+      over IP. Passes [ttl] to the IP stack if given. *)
 end
 
 module type ICMPV4 = sig
@@ -285,9 +285,10 @@ module type UDP = sig
 
   val write: ?src_port:int -> ?ttl:int -> dst:ipaddr -> dst_port:int -> t -> buffer ->
     (unit, error) result io
-  (** [write ~src_port ~dst ~dst_port udp data] is a thread
+  (** [write ~src_port ?ttl ~dst ~dst_port udp data] is a thread
       that writes [data] from an optional [src_port] to a [dst]
-      and [dst_port] IPv4 address pair. *)
+      and [dst_port] IPv4 address pair. An optional [ttl] is passed
+      through to the IP stack. *)
 
 end
 

--- a/src/mirage_protocols.mli
+++ b/src/mirage_protocols.mli
@@ -237,7 +237,7 @@ module type ICMP = sig
       [buffer]. *)
 
   val write : t -> dst:ipaddr -> ?ttl:int -> buffer -> (unit, error) result io
-  (** [write t dst ?ttl buffer] sends the ICMP message in [buffer] to [dst]
+  (** [write t dst ~ttl buffer] sends the ICMP message in [buffer] to [dst]
       over IP. Passes [ttl] to the IP stack if given. *)
 end
 


### PR DESCRIPTION
I'd like to expose the optional `ttl` parameter of the underlying IP.write to ICMP.write and UDP.write, because I think its helpful to implement traceroute functionality.

* `ICMP.write`: add ttl parameter.


Talked about it for a moment with @hannesm at the retreat. 