### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-protocols-lwt.opam
+++ b/mirage-protocols-lwt.opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "mirage-protocols" {>= "2.0.0"}
   "ipaddr" {>= "3.0.0"}
   "macaddr"

--- a/mirage-protocols.opam
+++ b/mirage-protocols.opam
@@ -15,7 +15,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.04.2"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "mirage-device" {>= "1.0.0"}
   "mirage-flow" {>= "1.2.0"}
   "mirage-net" {>= "2.0.0"}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.