### PR TITLE
compatibility with older mirage

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,5 @@
 (library
  (name mirage_protocols)
  (public_name mirage-protocols)
- (libraries mirage-device mirage-flow duration fmt cstruct lwt ipaddr macaddr))
+ (libraries mirage-device mirage-flow duration fmt cstruct lwt ipaddr macaddr)
+ (wrapped false))

--- a/src/mirage_protocols_lwt.ml
+++ b/src/mirage_protocols_lwt.ml
@@ -1,0 +1,3 @@
+[@@@ocaml.deprecated "This module will be removed from MirageOS 4.0. Please use Mirage_protocols instead."]
+
+include Mirage_protocols


### PR DESCRIPTION
this allows a smooth transition path (mirage 3.6.0 --> 3.7.0) with some deprecations.