### PR TITLE
revise UDP and TCP signatures (fewer types, provide listen and unlisten)

### DIFF
--- a/mirage-protocols.opam
+++ b/mirage-protocols.opam
@@ -9,7 +9,7 @@ bug-reports:  "https://github.com/mirage/mirage-protocols/issues"
 tags:         ["org:mirage"]
 
 build: [
-  [ "dune" "subst" ] {pinned}
+  [ "dune" "subst" ] {dev}
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 
@@ -23,6 +23,7 @@ depends: [
   "lwt" {>= "4.0.0"}
   "ipaddr" {>= "4.0.0"}
   "macaddr" {>= "4.0.0"}
+  "cstruct" {>= "6.0.0"}
 ]
 synopsis: "MirageOS signatures for network protocols"
 description: """


### PR DESCRIPTION
Dear valuable reader,

the changes in this PR are backwards compatible for (unikernel) client code. Certainly, mirage-tcpip needs to be adapted to the new interface.

This PR covers (for both TCP and UDP)
- (a) removal of type `ipinput` that always was confusing to me, and since it is only used once (in `input`), we can spell it out
- (b) revise `listen` API - until now, a Mirage_stack.S contains `listen_tcp/listen_udp` functions (which are kept for backwards-compatibilty). Now, `listen` and `unlisten` are part of the UDP/TCP module types. This allows a tighter `input` signature (no `~listerners` anymore), and moves the listening business to the protocol layer in question. It also cleaned up the `type listener` in TCP.

I'm happy for any feedback you may have.